### PR TITLE
chore: rename config file and improve default config

### DIFF
--- a/config.go
+++ b/config.go
@@ -15,7 +15,7 @@ type Config struct {
 	WaitTime          int     `toml:"wait_time"`           // Time to wait before reset latencyWindow in seconds
 }
 
-const configPath = "config.toml"
+const configPath = "breaker-config.toml"
 
 var config *Config
 


### PR DESCRIPTION
Renames the config file to `breaker-config.toml` for better discoverability and updates the default configuration values, including adding WaitTime.