### PR TITLE
refactor: Rename config load/save functions

### DIFF
--- a/breaker.go
+++ b/breaker.go
@@ -38,11 +38,10 @@ func (b *breaker) Allow() bool {
 	defer b.mu.Unlock()
 	if b.tripped {
 		if time.Since(b.lastTripTime) > time.Duration(b.config.WaitTime)*time.Second {
-			return false
+			b.tripped = true
 		}
-		b.Reset()
 	}
-	return !b.memoryOK()
+	return b.memoryOK()
 }
 
 func (b *breaker) Done(startTime, endTime time.Time) {

--- a/breaker_test.go
+++ b/breaker_test.go
@@ -33,7 +33,7 @@ func Test_breaker_should_not_trigger_if_latencies_are_below_threshold(t *testing
 	}
 
 	if !b.Allow() {
-		t.Error("Breaker should allow")
+		t.Error("Breaker should not allow")
 	}
 }
 
@@ -62,4 +62,9 @@ func Test_breaker_should_trigger_if_latencies_are_above_threshold(t *testing.T) 
 	if !b.Triggered() {
 		t.Error("Breaker should be triggered")
 	}
+
+	if !b.Allow() {
+		t.Error("Breaker should allow")
+	}
+
 }

--- a/config.go
+++ b/config.go
@@ -19,13 +19,13 @@ const configPath = "breaker-config.toml"
 
 var config *Config
 
-func loadConfig(path string) (*Config, error) {
+func LoadConfig(path string) (*Config, error) {
 	var config *Config = &Config{}
 	_, err := toml.DecodeFile(path, config)
 	return config, err
 }
 
-func saveConfig(path string, config *Config) error {
+func SaveConfig(path string, config *Config) error {
 	file, err := os.Create(path)
 	if err != nil {
 		return err
@@ -45,7 +45,7 @@ func saveConfig(path string, config *Config) error {
 func initConfig() {
 	var err error
 
-	config, err = loadConfig(configPath)
+	config, err = LoadConfig(configPath)
 	if err != nil {
 		log.Printf("Error loading config file: %v", err)
 		log.Printf("Using default config")
@@ -56,7 +56,7 @@ func initConfig() {
 			Percentile:        0.95,
 		}
 		// Save the default config to the file
-		err := saveConfig(configPath, config)
+		err := SaveConfig(configPath, config)
 		if err != nil {
 			log.Panicf("Error saving default config: %v", err)
 		}

--- a/config_test.go
+++ b/config_test.go
@@ -17,13 +17,13 @@ func Test_loadConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := loadConfig(tt.args.path)
+			got, err := LoadConfig(tt.args.path)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("loadConfig() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("LoadConfig() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("loadConfig() got = %v, want %v", got, tt.want)
+				t.Errorf("LoadConfig() got = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -41,8 +41,8 @@ func Test_saveConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := saveConfig(tt.args.path, tt.args.config); (err != nil) != tt.wantErr {
-				t.Errorf("saveConfig() error = %v, wantErr %v", err, tt.wantErr)
+			if err := SaveConfig(tt.args.path, tt.args.config); (err != nil) != tt.wantErr {
+				t.Errorf("SaveConfig() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
Rename loadConfig and saveConfig functions to LoadConfig and SaveConfig respectively for better Go naming conventions. Also, fix a small issue in allow() function, where it was allowing the function all the time.