### PR TITLE
feat: Add configurable memory breaker

### DIFF
--- a/breaker/endpoints.go
+++ b/breaker/endpoints.go
@@ -171,7 +171,7 @@ func (b *BreakerAPI) GetPercentile(ctx *gin.Context) {
 
 func (b *BreakerAPI) SetWait(ctx *gin.Context) {
 
-	// error if wait is less than 1 seconds or greater or equal than 10 seconds
+	// error if wait is less than 1 second or greater or equal than 10 seconds
 	waitStr := ctx.Query("wait")
 	wait, err := strconv.Atoi(waitStr)
 	if err != nil {
@@ -205,4 +205,18 @@ func (b *BreakerAPI) GetWait(ctx *gin.Context) {
 	defer b.lock.Unlock()
 
 	ctx.JSON(http.StatusOK, gin.H{"wait": b.Config.WaitTime})
+}
+
+func AddEndpointToRouter(router *gin.Engine, breakerAPI *BreakerAPI) {
+	group := router.Group("/breaker")
+	group.GET("/memory", breakerAPI.GetMemory)
+	group.GET("/latency", breakerAPI.GetLatency)
+	group.GET("/latency_window_size", breakerAPI.GetLatencyWindowSize)
+	group.GET("/percentile", breakerAPI.GetPercentile)
+	group.GET("/wait", breakerAPI.GetWait)
+	group.GET("/set_memory", breakerAPI.SetMemory)
+	group.GET("/set_latency", breakerAPI.SetLatency)
+	group.GET("/set_latency_window_size", breakerAPI.SetLatencyWindowSize)
+	group.GET("/set_percentile", breakerAPI.SetPercentile)
+	group.GET("/set_wait", breakerAPI.SetWait)
 }

--- a/breaker/memory.go
+++ b/breaker/memory.go
@@ -1,6 +1,7 @@
 package breaker
 
 import (
+	"bytes"
 	"log"
 	"os"
 	"runtime"
@@ -12,8 +13,10 @@ var MemoryLimitFile = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
 func GetK8sMemoryLimit() (int64, error) {
 	data, err := os.ReadFile(MemoryLimitFile)
 	if err != nil {
+		log.Printf("Error reading memory limit file: %v", err)
 		return 0, err
 	}
+	data = bytes.TrimSpace(data)
 	limit, err := strconv.ParseInt(string(data), 10, 64)
 	if err != nil {
 		return 0, err
@@ -33,6 +36,7 @@ func init() {
 	var err error
 	MemoryLimit, err = GetK8sMemoryLimit()
 	if err != nil {
+		log.Printf("Error getting memory limit: %v", err)
 		panic(err)
 	}
 }

--- a/tests/memory_test.go
+++ b/tests/memory_test.go
@@ -27,7 +27,7 @@ func TestK8SGetMemoryLimit(t *testing.T) {
 
 		}
 	}(file)
-	_, err = file.WriteString("536870912")
+	_, err = file.WriteString("536870912\n")
 	if err != nil {
 		return
 	} // 512 MB


### PR DESCRIPTION
This commit introduces a configurable memory breaker based on K8s memory limits, allowing users to dynamically adjust the memory threshold via API endpoints. It also fixes a bug in the memory limit test and improves error handling.