### PR TITLE
feat: Implement BreakerDriver with API endpoints

### DIFF
--- a/breaker/config.go
+++ b/breaker/config.go
@@ -15,7 +15,7 @@ type Config struct {
 	WaitTime          int     `toml:"wait_time"`           // Time to wait before reset LatencyWindow in seconds
 }
 
-const configPath = "breaker-Config.toml"
+const configPath = "BreakerDriver-Config.toml"
 
 var config *Config
 

--- a/breaker/latency.go
+++ b/breaker/latency.go
@@ -61,6 +61,6 @@ func (lw *LatencyWindow) BelowThreshold(threshold int64) bool {
 }
 
 // LatencyOK Return true if the LatencyWindow is OK
-func (b *breaker) LatencyOK() bool {
+func (b *BreakerDriver) LatencyOK() bool {
 	return b.latencyWindow.BelowThreshold(b.config.LatencyThreshold)
 }

--- a/breaker/memory.go
+++ b/breaker/memory.go
@@ -51,7 +51,7 @@ func MemoryUsage() int64 {
 
 // MemoryOK Return true if the memory usage is above the threshold. The threshold is
 // calculated based on the memory limit of the container
-func (b *breaker) MemoryOK() bool {
+func (b *BreakerDriver) MemoryOK() bool {
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m)
 

--- a/example/Gemfile
+++ b/example/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+# gem "rails"

--- a/example/client.rb
+++ b/example/client.rb
@@ -55,6 +55,8 @@ def wait_time
   consult('wait')
 end
 
+def memory_usage; consult('memory_usage'); end
+
 def set_memory(memory)
   set('set_memory', memory)
 end
@@ -74,3 +76,5 @@ end
 def set_wait_time(wait_time)
   set('set_wait', wait_time)
 end
+
+def get_latencies(threshold); consult("latencies_above_threshold/#{threshold}"); end

--- a/example/console.rb
+++ b/example/console.rb
@@ -1,0 +1,9 @@
+# give a console on ruby for calling the client function
+
+require_relative 'client'
+
+require 'irb'
+
+ARGV.clear # otherwise, IRB will try to parse the arguments
+
+IRB.start(__FILE__)


### PR DESCRIPTION
This commit introduces a new BreakerDriver struct and its implementation, along with API endpoints for configuration and monitoring. The BreakerDriver uses a LatencyWindow to track latencies and triggers based on memory and latency thresholds.

The API endpoints allow setting and getting configuration parameters such as memory threshold, latency threshold, latency window size, percentile, and wait time. A new endpoint to retrieve latencies above a threshold has also been added.

A ruby client has also been created to test the endpoints in example/client.rb