### PR TITLE
refactor(api): Refactor BreakerDriver endpoint group name

### DIFF
--- a/breaker/endpoints.go
+++ b/breaker/endpoints.go
@@ -240,7 +240,7 @@ func (b *BreakerAPI) LatenciesAboveThreshold(ctx *gin.Context) {
 }
 
 func AddEndpointToRouter(router *gin.Engine, breakerAPI *BreakerAPI) {
-	group := router.Group("/BreakerDriver")
+	group := router.Group("/breaker")
 	group.GET("/memory", breakerAPI.GetMemory)
 	group.GET("/latency", breakerAPI.GetLatency)
 	group.GET("/latency_window_size", breakerAPI.GetLatencyWindowSize)


### PR DESCRIPTION
Renames the endpoint group from "/BreakerDriver" to "/breaker" for better consistency and readability. This change affects the base path for all API endpoints related to the BreakerDriver.