### PR TITLE
fix: Correct percentile parsing and configure client

### DIFF
--- a/breaker/endpoints.go
+++ b/breaker/endpoints.go
@@ -146,7 +146,7 @@ func (b *BreakerAPI) SetPercentile(ctx *gin.Context) {
 
 	// error if percentile is less than 40 or greater than 99
 	percentileStr := ctx.Param("percentile")
-	percentile, err := strconv.ParseFloat(percentileStr, 64)
+	percentile, err := strconv.Atoi(percentileStr)
 	if err != nil {
 		log.Printf("Invalid percentile: %v", percentileStr)
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid percentile"})

--- a/example/client.rb
+++ b/example/client.rb
@@ -1,16 +1,9 @@
 # simple client for testing go go-breaker package
 
-require 'awesome_print'
 require 'json'
 require 'http'
 require 'byebug'
 
-# Cli parameters are the host and port of the server. If not provided, default to localhost:8080
-
-host = ARGV[0] || 'localhost'
-port = ARGV[1] || 8080
-
-$url = "http://#{host}:#{port}/breaker/"
 
 def consult(endpoint_name)
   url = "#{$url}#{endpoint_name}"

--- a/example/console.rb
+++ b/example/console.rb
@@ -2,6 +2,13 @@
 
 require_relative 'client'
 
+# Cli parameters are the host and port of the server. If not provided, default to localhost:8080
+
+host = ARGV[0] || 'localhost'
+port = ARGV[1] || 8080
+
+$url = "http://#{host}:#{port}/breaker/"
+
 require 'irb'
 
 ARGV.clear # otherwise, IRB will try to parse the arguments


### PR DESCRIPTION
The percentile value is parsed as an integer instead of a float. The example client now accepts host and port arguments to configure the server address.