### PR TITLE
fix: correct index calculation in LatencyWindow.Add

### DIFF
--- a/breaker/latency.go
+++ b/breaker/latency.go
@@ -22,8 +22,9 @@ func NewLatencyWindow(size int) *LatencyWindow {
 // Add This function adds a new LatencyWindow measurement to the window and must run
 // in a critical section
 func (lw *LatencyWindow) Add(startTime, endTime time.Time) {
+	n := len(lw.Values)
 	lw.Values[lw.Index] = endTime.Sub(startTime).Milliseconds()
-	lw.Index = (lw.Index + 1) % lw.Size // Circular buffer
+	lw.Index = (lw.Index + 1) % n // Circular buffer
 	lw.NeedToSort = true
 }
 


### PR DESCRIPTION
The index calculation in the LatencyWindow.Add function was incorrectly using `lw.Size` instead of the actual length of the `lw.Values` slice (n). This caused the circular buffer to not function correctly when the slice was not fully populated. This commit fixes the index calculation to use `n` which ensures the circular buffer works as expected.